### PR TITLE
Parameterize cert values

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,17 +10,18 @@ Vagrant::DEFAULT_SERVER_URL.replace('https://vagrantcloud.com')
 
 Vagrant.configure("2") do |config|
 
-  if vars["trust_cert"] == 1
+  if (vars["trust_cert"] || 1) == 1
     [:up, :provision].each do |command|
-      if !File.exist?(vars['certpath'])
+      certpath = vars['certpath'] || "/usr/local/etc"
+      if !File.exist?(certpath)
         config.trigger.before command do
-          run "sudo mkdir -p #{vars['certpath']}"
-          run "sudo chown #{`whoami`} #{vars['certpath']}"
+          run "sudo mkdir -p #{certpath}"
+          run "sudo chown #{`whoami`} #{certpath}"
         end
       end
 
       config.trigger.after command do
-        run "sudo security add-trusted-cert -d -k '/Library/Keychains/System.keychain' #{vars['certpath']}/ssl/certs/#{vars['hostname']}.crt"
+        run "sudo security add-trusted-cert -d -k '/Library/Keychains/System.keychain' #{certpath}/ssl/certs/#{vars['hostname']}.crt"
       end
     end
   end

--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -30,5 +30,13 @@ mysql_databases:
 packages:
     - git
 
-trust_cert: 1
-certpath: /usr/local/etc
+# The following are default cert values.
+#
+# Change trust_cert to 0 if for some reason you don’t want to
+# trust the certificate automatically
+#
+# You can also change the certpath for the local copy of the
+# self-signed cert if you really want to.
+#
+# trust_cert: 1
+# certpath: /usr/local/etc


### PR DESCRIPTION
Tested with no `trust_cert` or `certpath` in the Vagrantfile; tested with `trust_cert = 0` in the Vagrantfile; tested with `trust_cert = 1` and a custom `certpath`; and tested with no `trust_cert` and a custom `certpath`.