### PR TITLE
Allow box overrides per project and support official xenial box by de…

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,6 +5,7 @@
 plugins = %w(
   vagrant-hostsupdater
   vagrant-triggers
+  vagrant-disksize
 )
 
 plugins.keep_if { |plugin| not Vagrant.has_plugin? plugin }

--- a/ansible/system_check/ensure_keypair.yml
+++ b/ansible/system_check/ensure_keypair.yml
@@ -12,4 +12,6 @@
     insertbefore: BOF
     block: |
       Host *
+      IgnoreUnknown AddKeysToAgent,UseKeychain
       AddKeysToAgent yes
+      UseKeychain yes

--- a/ansible/system_check/ensure_keypair.yml
+++ b/ansible/system_check/ensure_keypair.yml
@@ -1,0 +1,15 @@
+---
+# This is inherently idempotent and will *not* overwrite an existing SSH key.
+- name: Create a 2048-bit SSH key for user
+  user:
+    name: "{{ lookup('env','USER') }}"
+    generate_ssh_key: yes
+
+- name: Ensure key will be forwarded
+  blockinfile:
+    create: yes
+    path: ~/.ssh/config
+    insertbefore: BOF
+    block: |
+      Host *
+      AddKeysToAgent yes

--- a/ansible/system_check/main.yml
+++ b/ansible/system_check/main.yml
@@ -12,3 +12,4 @@
 
   tasks:
     - include: fix_old_box_metadata_urls.yml
+    - include: ensure_keypair.yml


### PR DESCRIPTION
This changes the default box to the official `ubuntu/xenial64` box, but it also allows project-specific overrides by looking for an `ansible/version` file before the `ansible/roles/version` file. In the event that roles is updated in a project (which should theoretically never be required unless a new dependency is only available in a later version of `roles`), just put `bento/ubuntu-16.04` in `ansible/version`. This will require the disksize plugin (`vagrant plugin install vagrant-disksize`) as discussed at https://github.com/fostermadeco/ansible-roles/issues/24.