### PR TITLE
Delete cert file from system and certificate from keychain on destroy

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,8 +11,11 @@ Vagrant::DEFAULT_SERVER_URL.replace('https://vagrantcloud.com')
 Vagrant.configure("2") do |config|
 
   if (vars["trust_cert"] || 1) == 1
-    [:up, :provision].each do |command|
-      certpath = vars['certpath'] || "/usr/local/etc"
+    certpath = vars['certpath'] || '/usr/local/etc'
+    cert = certpath + "/ssl/certs/#{vars['hostname']}.crt"
+    keychain = '/Library/Keychains/System.keychain'
+
+    [:up, :provision, :reload].each do |command|
       if !File.exist?(certpath)
         config.trigger.before command do
           run "sudo mkdir -p #{certpath}"
@@ -21,9 +24,18 @@ Vagrant.configure("2") do |config|
       end
 
       config.trigger.after command do
-        run "sudo security add-trusted-cert -d -k '/Library/Keychains/System.keychain' #{certpath}/ssl/certs/#{vars['hostname']}.crt"
+        system("sudo security verify-cert -c #{cert} > /dev/null 2>&1 || sudo security add-trusted-cert -d -k #{keychain} #{cert}")
       end
     end
+
+    [:destroy].each do |command|
+      if File.exist?(cert)
+        config.trigger.after command do
+          system("security find-certificate -ac #{vars['hostname']} -Z #{keychain} | awk -F: '/SHA-1 hash/{ print $2 }' | xargs -I {} sudo security delete-certificate -Z {} #{keychain}")
+          File.delete(cert)
+        end
+      end
+     end
   end
 
   config.vm.box = version


### PR DESCRIPTION
Fixes #19, even though that description is not really accurate. What I wanted to solve was the proliferation of certificates in your system keychain if you destroyed and rebuilt the VM multiple times. Now, `vagrant destroy` will delete the local copy of the certificate and remove it from the system keychain — so there should only ever be one copy of the certificate in your keychain at any given time.

To test, run `vagrant up` and verify the local copy of the cert exists and is in your keychain. Run `vagrant provision` or `vagrant reload --provision` and verify the same. Run `vagrant destroy` and verify that the local copy was deleted and the certificate was removed from the keychain. Note, you will have to quit and reopen the Keychain app to verify the latter, because it will not actually disappear from the GUI in realtime.