### PR TITLE
Change into project directory on login

### DIFF
--- a/ansible/files/dot/.bash_aliases
+++ b/ansible/files/dot/.bash_aliases
@@ -1,1 +1,8 @@
-source ~/.bashrc
+alias ls='ls -F --color=always'
+alias dir='dir -F --color=always'
+alias ll='ls -l'
+alias cp='cp -iv'
+alias rm='rm -i'
+alias mv='mv -iv'
+alias grep='grep --color=auto -in'
+alias ..='cd ..'

--- a/ansible/files/dot/.bash_profile
+++ b/ansible/files/dot/.bash_profile
@@ -2,3 +2,49 @@ source ~/.bashrc
 
 PATH=$PATH:$HOME/bin
 export PATH
+
+[ -r /etc/bashrc ] && source /etc/bashrc
+[ -r /etc/bash_completion ] && source /etc/bash_completion
+[ -r ~/.git-completion.bash ] && source ~/.git-completion.bash
+[ -r ~/.git-prompt.sh ] && source ~/.git-prompt.sh
+[ -r /usr/local/rvm/scripts/rvm ] && source /usr/local/rvm/scripts/rvm
+
+__has_parent_dir () {
+    # Utility function so we can test for things like .git/.hg without firing up a
+    # separate process
+    test -d "$1" && return 0;
+
+    current="."
+    while [ ! "$current" -ef "$current/.." ]; do
+        if [ -d "$current/$1" ]; then
+            return 0;
+        fi
+        current="$current/..";
+    done
+
+    return 1;
+}
+
+__vcs_name() {
+    if [ -d .svn ]; then
+        echo "-[svn]";
+    elif __has_parent_dir ".git"; then
+        echo "-[$(__git_ps1 'git %s')]";
+    elif __has_parent_dir ".hg"; then
+        echo "-[hg $(hg branch)]"
+    fi
+}
+
+black=$(tput -Txterm setaf 0)
+red=$(tput -Txterm setaf 1)
+green=$(tput -Txterm setaf 2)
+yellow=$(tput -Txterm setaf 3)
+dk_blue=$(tput -Txterm setaf 4)
+pink=$(tput -Txterm setaf 5)
+lt_blue=$(tput -Txterm setaf 6)
+
+bold=$(tput -Txterm bold)
+reset=$(tput -Txterm sgr0)
+
+# Nicely formatted terminal prompt
+export PS1='\n\[$bold\]\[$black\][\[$dk_blue\]\@\[$black\]]-[\[$green\]\u\[$yellow\]@\[$green\]\h\[$black\]]-[\[$pink\]\w\[$black\]]\[\033[0;33m\]$(__vcs_name) \[\033[00m\]\[$reset\]\n\[$reset\]\$ '

--- a/ansible/provision.yml
+++ b/ansible/provision.yml
@@ -2,23 +2,32 @@
 
   # Specifying a role will run all of the role’s tasks.
   roles:
-      - system
-      - lamp
+    - system
+    - lamp
 
   tasks:
-      - name: copy profile files
-        copy: src={{ item }} dest=/home/vagrant force=yes
-        with_fileglob:
-            - files/dot/.*
+    - name: copy profile files
+      copy:
+        src: '{{ item }}'
+        dest: /home/vagrant
+        force: no
+      with_fileglob:
+        - files/dot/.*
 
-      # Add additional tasks as needed. For example,
-      #
-      # - name: install app dependencies
-      #   command: composer install
-      #   args:
-      #       chdir: /var/www/{{ hostname }}
+    - name: change into project directory on login
+      lineinfile:
+        path: ~/.bashrc
+        line: cd /var/www/{{ hostname }}
+        state: present
 
-      # If you do not want to run all of a role’s tasks, include
-      # a single task like this:
-      #
-      # - include: roles/nosql/tasks/install_redis.yml
+    # Add additional tasks as needed. For example,
+    #
+    # - name: install app dependencies
+    #   command: composer install
+    #   args:
+    #     chdir: /var/www/{{ hostname }}
+
+    # If you do not want to run all of a role’s tasks, include
+    # a single task like this:
+    #
+    # - include: roles/nosql/tasks/install_redis.yml


### PR DESCRIPTION
@kellypacker I’d been meaning to add this for a while, as I usually set it up in my own projects manually. I also took this as an opportunity to clean up some of the dot files so that provisioning remains idempotent.

The relevant change is in `provision.yml`, so it can be commented out if necessary — but, like you, I don’t know of any projects where this would not be a desired feature.

I tested it on both the `master` and `trusty` branches.

Fixes #30 