### PR TITLE
Feature/ensure ansible version

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -19,13 +19,17 @@ end
 
 ####
 
+if ['up', 'provision', 'reload'].include?(ARGV[0])
+  unless system('ansible-playbook ansible/system_check/main.yml -i localhost,')
+    raise 'System check failed'
+  end
+end
+
 require 'yaml'
 
 dir = File.dirname(File.expand_path(__FILE__))
 vars = YAML.load_file("#{dir}/ansible/group_vars/all")
 version = YAML.load_file("#{dir}/ansible/roles/version")
-
-Vagrant::DEFAULT_SERVER_URL.replace('https://vagrantcloud.com')
 
 Vagrant.configure("2") do |config|
 

--- a/ansible/system_check/fix_old_box_metadata_urls.yml
+++ b/ansible/system_check/fix_old_box_metadata_urls.yml
@@ -1,0 +1,16 @@
+---
+- name: find files with atlas urls
+  find:
+    paths: ~/.vagrant.d/boxes/
+    pattern: metadata_url
+    recurse: yes
+    contains: .*atlas\.hashicorp\.com.*
+  register: found
+
+- name: replace hashicorp domain with vagrantcloud
+  replace:
+    path: '{{ item.path }}'
+    regexp: '(.*)atlas\.hashicorp\.com(.*)'
+    replace: '\1vagrantcloud.com\2'
+  with_items: '{{ found.files }}'
+  when: found.matched != 0

--- a/ansible/system_check/main.yml
+++ b/ansible/system_check/main.yml
@@ -1,0 +1,6 @@
+---
+- hosts: localhost
+  connection: local
+
+  tasks:
+    - include: fix_old_box_metadata_urls.yml

--- a/ansible/system_check/main.yml
+++ b/ansible/system_check/main.yml
@@ -3,7 +3,7 @@
   connection: local
 
   pre_tasks:
-    - name: Verify Ansible meets version requirements with nondeprecated check.
+    - name: Verify Ansible meets the minimum version requirement
       fail:
         msg: >
           Please update Ansible to version 2.4 or higher by running

--- a/ansible/system_check/main.yml
+++ b/ansible/system_check/main.yml
@@ -2,23 +2,13 @@
 - hosts: localhost
   connection: local
 
-  vars:
-    version_message: >
-      Please update Ansible to version 2.4 or higher by running
-      `pip install --upgrade ansible`.
-
   pre_tasks:
     - name: Verify Ansible meets version requirements with nondeprecated check.
-      assert:
-        that: "ansible_version.full is version_compare('2.4', '>=')"
-        msg: '{{ version_message }}'
-      when: ansible_version.major == 2 and ansible_version.minor in [2, 3]
-
-    - name: Verify Ansible meets version requirements with deprecated check.
-      assert:
-        that: "ansible_version.full | version_compare('2.4', '>=')"
-        msg: '{{ version_message }}'
-      when: ansible_version.major <= 1 or (ansible_version.major == 2 and ansible_version.minor <= 1)
+      fail:
+        msg: >
+          Please update Ansible to version 2.4 or higher by running
+          `pip install --upgrade ansible`.
+      when: ansible_version.major <= 1 or (ansible_version.major == 2 and ansible_version.minor <= 3)
 
   tasks:
     - include: fix_old_box_metadata_urls.yml

--- a/ansible/system_check/main.yml
+++ b/ansible/system_check/main.yml
@@ -2,5 +2,23 @@
 - hosts: localhost
   connection: local
 
+  vars:
+    version_message: >
+      Please update Ansible to version 2.4 or higher by running
+      `pip install --upgrade ansible`.
+
+  pre_tasks:
+    - name: Verify Ansible meets version requirements with nondeprecated check.
+      assert:
+        that: "ansible_version.full is version_compare('2.4', '>=')"
+        msg: '{{ version_message }}'
+      when: ansible_version.major == 2 and ansible_version.minor in [2, 3]
+
+    - name: Verify Ansible meets version requirements with deprecated check.
+      assert:
+        that: "ansible_version.full | version_compare('2.4', '>=')"
+        msg: '{{ version_message }}'
+      when: ansible_version.major <= 1 or (ansible_version.major == 2 and ansible_version.minor <= 1)
+
   tasks:
     - include: fix_old_box_metadata_urls.yml


### PR DESCRIPTION
This is preliminary to fixing #4.

Both versions of the requirement check are necessary to be effective on versions of Ansible back to 1 and avoid any deprecation warnings. I checked it with 1.9.6, 2.0, 2.1, 2.2 and 2.3 by running, for example, `pip install ansible==2.2`.

This is another that builds on the `system_check` collection, so the relevant change is 8cfa04ce